### PR TITLE
Update installation instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,8 +25,7 @@ To install the latest release, please run the following commands in OpenSesame's
 .. code-block:: python
 
     import pip
-    pip.main(['install', '--process-dependency-links',
-      'https://github.com/psynteract/psynteract-os/archive/stable.zip'])
+    pip.main(['install', 'https://github.com/psynteract/psynteract-os/archive/stable.zip'])
 
 You'll need to restart OpenSesame after the installation for the plugins and
 extension to work.
@@ -41,8 +40,7 @@ If you are using a recent version of OpenSesame for Mac OS, you might need to ch
 .. code-block:: python
 
     import pip._internal
-    pip._internal.main(['install', '--process-dependency-links',
-      'https://github.com/psynteract/psynteract-os/archive/stable.zip'])
+    pip._internal.main(['install', 'https://github.com/psynteract/psynteract-os/archive/stable.zip'])
 
 The `installation of plugins
 <http://osdoc.cogsci.nl/manual/environment/#installing-plugins-and-extensions>`__

--- a/setup.py
+++ b/setup.py
@@ -83,12 +83,12 @@ setup(
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
-        'psynteract'
+        'psynteract' @ 'https://github.com/psynteract/psynteract-py/releases/download/v0.7.0/psynteract-0.7.0.tar.gz#egg=psynteract-0.7.0'
     ],
 
-    dependency_links = [
-        'https://github.com/psynteract/psynteract-py/releases/download/v0.7.0/psynteract-0.7.0.tar.gz#egg=psynteract-0.7.0'
-    ],
+    #dependency_links = [
+        
+    #],
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ setup(
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
-        'psynteract' @ 'https://github.com/psynteract/psynteract-py/releases/download/v0.7.0/psynteract-0.7.0.tar.gz#egg=psynteract-0.7.0'
+        'psynteract @ https://github.com/psynteract/psynteract-py/releases/download/v0.7.0/psynteract-0.7.0.tar.gz#egg=psynteract-0.7.0'
     ],
 
     #dependency_links = [


### PR DESCRIPTION
the flag `--process-dependency-links` is not supported anymore in the current pip versions (at least the ones Opensesame uses). Instead the dependency links are directly linked to the required packages with the `@` syntax (see commit). 

On my system, that fixed the broken installation as described in the readme. 
(related discussion on the OS forum: https://forum.cogsci.nl/discussion/comment/24524#Comment_24524)